### PR TITLE
expand github link to artpop

### DIFF
--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -26,7 +26,7 @@ Installing the Development Version
 ==================================
 
 If you're feeling adventurous, you can download the development 
-version of `ArtPop` from `GitHub <https://github.com/>`_ using ``git``::
+version of `ArtPop` from `GitHub <https://github.com/ArtificialStellarPopulations/ArtPop>`_ using ``git``::
     
     git clone git://github.com/ArtificialStellarPopulations/ArtPop.git
 


### PR DESCRIPTION
A very minor quibble, but... it seemed better to go straight to the artpop github page!