### PR TITLE
Minor changes to build_galaxy function in stars/imf.py

### DIFF
--- a/src/artpop/stars/imf.py
+++ b/src/artpop/stars/imf.py
@@ -167,8 +167,29 @@ def build_galaxy(stellar_mass, num_stars_iter=1e5, m_min=0.08, m_max=120, imf='k
         solar masses.
     num_stars_iter : int
         Number of stars to generate at each iteration. Lower this
-        number (at the expense of speed) to get a more accurate total mass.
-
+        number (at the expense of speed) to get a more accurate total mass.)
+    num_stars : int
+        Number of stars to sample.
+    m_min : float, optional
+        Minimum stellar mass.
+    m_max : float, optional
+        Maximum stellar mass.
+    imf : str or dict
+        Which IMF to use, if str then must be one of pre-defined: 'kroupa',
+        'scalo' or 'salpeter'. Can also specify broken power law as dict,
+        which must contain either 'a' as a Float (describing the slope of a
+        single power law) or 'a' (a list with 3 elements describing the slopes
+        of a broken power law) and 'b' (a list  with 2 elements describing the
+        locations of the breaks).
+    num_mass_bins : int, optional
+        Number of mass bins in logarithmic spaced mass grid.
+    random_state : `None`, int, list of ints, or `~numpy.random.RandomState`
+        If `None`, return the `~numpy.random.RandomState` singleton used by
+        ``numpy.random``. If `int`, return a new `~numpy.random.RandomState`
+        instance seeded with the `int`.  If `~numpy.random.RandomState`,
+        return it. Otherwise raise ``ValueError``.
+    imf_kw : dict, optional
+        Keyword arguments for the imf function.
     Returns
     -------
     stars : `~numpy.ndarray`


### PR DESCRIPTION
Just two minor changes to the` build_galaxy` function. 

First: is copying the code used to build the cdf that is used to sample the imf. This forgoes the need to re-build it every loop when calling `sample_imf` speeding up the whole thing by a lot

Second: Adding a catch if the number of stars per iteration was <1. This is fairly uncommon but I hit a few infinite loops when specifying a `mag_lim`