### PR TITLE
added extinction option to observe methods; did some random cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ ENV/
 *.out
 *.synctex.gz
 sandbox
+.idea

--- a/src/artpop/filters.py
+++ b/src/artpop/filters.py
@@ -1,7 +1,6 @@
 # Standard library
 import os
 import pickle
-from glob import glob
 
 # Third-party
 import numpy as np

--- a/src/artpop/source.py
+++ b/src/artpop/source.py
@@ -12,7 +12,6 @@ from scipy.special import gammaincinv, gamma
 from . import MIST_PATH
 from .stars import SSP, MISTSSP, MISTIsochrone, constant_sb_stars_per_pix
 from .space import sersic_xy, plummer_xy, uniform_xy, Plummer2D, Constant2D
-from .filters import load_zero_point_converter
 from .util import check_units, check_xy_dim
 
 

--- a/src/artpop/stars/imf.py
+++ b/src/artpop/stars/imf.py
@@ -1,8 +1,6 @@
 # Third-party
 import numpy as np
-from scipy.integrate import quad
 from scipy.interpolate import interp1d
-from astropy import units as u
 from typing import Iterable
 
 # Project
@@ -196,7 +194,7 @@ def build_galaxy(stellar_mass, num_stars_iter=1e5, m_min=0.08, m_max=120, imf='k
         Stellar masses of all the stars.
     """
     
-    #Build CDF, taken from sample_imf above
+    # build CDF, taken from sample_imf above
     rng = check_random_state(random_state)
     bin_edges = np.logspace(np.log10(m_min),
                             np.log10(m_max),
@@ -212,7 +210,7 @@ def build_galaxy(stellar_mass, num_stars_iter=1e5, m_min=0.08, m_max=120, imf='k
     total_mass = 0.0
     stellar_mass = check_units(stellar_mass, 'Msun').to('Msun').value
     
-    #Ensure the while loop does not get stuck
+    # ensure the while loop does not get stuck
     if num_stars_iter < 1: 
         num_stars_iter = 1
     
@@ -260,14 +258,16 @@ class IMFIntegrator(object):
                 self.name = params
             else:
                 raise Exception(
-                        f'{params} is not one of the pre-defined IMFs: ' \
+                        f'{params} is not one of the pre-defined IMFs: '
                         + ', '.join(imf_params_dict.keys())
                     )
 
         elif type(params) == dict:
-            if ('a' in params.keys() and
+            if (
+                'a' in params.keys() and
                 'b' in params.keys() and
-                isinstance(params['a'], Iterable)):
+                isinstance(params['a'], Iterable)
+            ):
                 self.a = params['a']
                 self.b = params['b']
                 self.name = 'custom'
@@ -287,8 +287,8 @@ class IMFIntegrator(object):
         self.num_norm = self.integrate(m_min, m_max, None)
         self.mass_norm = self.m_integrate(m_min, m_max, None)
 
-    def weights(self, mass_grid, norm_type=None,
-        norm_mass_min=None, norm_mass_max=None):
+    def weights(self, mass_grid, norm_type=None, norm_mass_min=None,
+                norm_mass_max=None):
         """
         Calculate the weights of the IMF at grid of stellar masses.
 
@@ -376,7 +376,7 @@ class IMFIntegrator(object):
         a0,a1,a2 = self.a
         b0,b1 = self.b
 
-        #Define constants to normalize functions
+        # define constants to normalize functions
         c0 = b0**a0
         c1 = b0**a1
         c2 = (b1 * (b0 / b1)**(a1 / a2) )**a2
@@ -470,7 +470,7 @@ class IMFIntegrator(object):
             Upper stellar mass bound of integral.
         norm: : Bool or Float
             Whether or not to normalize the integral, default False. If True
-            will normalize by the total stelllar mass. If a Float is given,
+            will normalize by the total stellar mass. If a Float is given,
             then will use that value as the normalization.
 
         Returns

--- a/src/artpop/stars/isochrones.py
+++ b/src/artpop/stars/isochrones.py
@@ -4,23 +4,23 @@ import os
 # Third-party
 import numpy as np
 from numpy.lib.recfunctions import append_fields
-from scipy.integrate import quad
 from scipy.interpolate import interp1d
 from astropy.table import Table
 from astropy import units as u
 
 # Project
-from ._read_mist_models import IsoCmdReader, IsoReader
+from ._read_mist_models import IsoCmdReader
 from .imf import IMFIntegrator
 from .. import MIST_PATH
 from ..log import logger
 from ..filters import phot_system_list, get_filter_names
 from ..filters import load_zero_point_converter
 from ..util import check_units, fetch_mist_grid_if_needed
-phot_str_helper = {p.lower():p for p in phot_system_list}
 
 
 __all__ = ['fetch_mist_iso_cmd', 'Isochrone', 'MISTIsochrone']
+
+phot_str_helper = {p.lower(): p for p in phot_system_list}
 
 
 class Isochrone(object):

--- a/src/artpop/stars/populations.py
+++ b/src/artpop/stars/populations.py
@@ -5,8 +5,6 @@ import numpy as np
 from copy import deepcopy
 
 # Third-party
-from scipy.integrate import quad
-from scipy.interpolate import interp1d
 from astropy.table import Table
 from astropy import units as u
 
@@ -14,7 +12,6 @@ from astropy import units as u
 from .. import MIST_PATH
 from ..util import check_random_state, check_units
 from ..log import logger
-from ..filters import *
 from .imf import sample_imf, build_galaxy, IMFIntegrator
 from .isochrones import MISTIsochrone
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,6 +1,4 @@
 # Standard library
-import os
-import pickle
 from unittest import TestCase
 
 # Third-party
@@ -99,3 +97,16 @@ class TestImage(TestCase):
         obs = imager.observe(src, 'my_i', exptime=100 * u.s, psf=self.psf)
         self.assertAlmostEqual(100, obs.src_counts.sum())
 
+    def test_add_extinction(self):
+        """Test that extinction is correctly applied in the observe methods."""
+        imager = artpop.IdealImager()
+        obs_no_ext = imager.observe(self.src, 'LSST_i', a_lam=0.0)
+        obs_with_ext = imager.observe(self.src, 'LSST_i', a_lam=1.0)
+        dm = 2.5 * np.log10(obs_no_ext.image.sum()) - 2.5 * np.log10(obs_with_ext.image.sum())
+        self.assertEqual(1.0, dm)
+
+        imager = artpop.ArtImager('LSST', random_state=1333)
+        obs_no_ext = imager.observe(self.src, 'LSST_i', 10000 * u.hr, a_lam=0.0)
+        obs_with_ext = imager.observe(self.src, 'LSST_i', 10000 * u.hr, a_lam=1.0)
+        dm = 2.5 * np.log10(obs_no_ext.image.sum()) - 2.5 * np.log10(obs_with_ext.image.sum())
+        self.assertAlmostEqual(1.0, dm)


### PR DESCRIPTION
This PR adds an option to apply extinction `a_lam` to injected sources. The option is added to the `observe` imager methods. I added a unit test to make sure the extinction is applied correctly. 

I also did some random cleanup like removing unused imports. 