### PR TITLE
Add extinction option round 2

### DIFF
--- a/src/artpop/source.py
+++ b/src/artpop/source.py
@@ -10,6 +10,7 @@ from scipy.special import gammaincinv, gamma
 
 # Project
 from . import MIST_PATH
+from .log import logger
 from .stars import SSP, MISTSSP, MISTIsochrone, constant_sb_stars_per_pix
 from .space import sersic_xy, plummer_xy, uniform_xy, Plummer2D, Constant2D
 from .util import check_units, check_xy_dim
@@ -94,6 +95,15 @@ class Source(object):
         if Source not in src.__class__.__mro__:
             raise Exception(f'{type(src)} is not a valid Source object')
         new = deepcopy(self)
+        for s in [new, src]:
+            if hasattr(s, 'sp') and s.sp.mag_limit is not None:
+                logger.warning(
+                    'Composite source objects currently only support '
+                    'discrete components.\nIf you want to include smooth '
+                    'components (i.e., mag_limit is not None),\n'
+                    'add the individual source images together.'
+                )
+                break
         if not np.allclose(new.xy_dim, src.xy_dim):
             raise Exception('Sources must have the same xy_dim')
         if new.labels is None:

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -74,7 +74,7 @@ class TestImage(TestCase):
         obs = imager.observe(self.src, 'LSST_i', exptime=1*u.min, sky_sb=19)
         self.assertEqual((201, 201), obs.image.shape)
         self.assertGreater(
-            0.02, abs(100 * (38869053 -  obs.image.sum()) / obs.image.sum()))
+            0.02, abs(100 * (38869053 - obs.image.sum()) / obs.image.sum()))
         self.assertGreater(
             0.03, abs(100 * (962 - obs.image.mean()) / obs.image.mean()))
 

--- a/tests/test_stars.py
+++ b/tests/test_stars.py
@@ -19,8 +19,8 @@ class TestStars(TestCase):
         """Build single isochrone object for all test cases."""
         with open(iso_fn, 'rb') as f:
             iso_table = Table(pickle.load(f))
-        self.filters =['LSST_u', 'LSST_g', 'LSST_r',
-                       'LSST_i', 'LSST_z', 'LSST_y']
+        self.filters = ['LSST_u', 'LSST_g', 'LSST_r',
+                        'LSST_i', 'LSST_z', 'LSST_y']
         self.iso = Isochrone(
             mini=iso_table['initial_mass'],
             mact=iso_table['star_mass'],
@@ -63,9 +63,9 @@ class TestStars(TestCase):
     def test_ssp(self):
         """Test SSP objects."""
         ssp = SSP(self.iso, num_stars=1e5, random_state=1)
-        self.assertAlmostEqual(42503.7698205, ssp.total_mass.value,3)
+        self.assertAlmostEqual(42503.7698205, ssp.total_mass.value, 3)
         self.assertAlmostEqual(
-            30038.3808821, ssp.total_initial_live_mass.value,3)
+            30038.3808821, ssp.total_initial_live_mass.value, 3)
         ssp_2 = SSP(self.iso, num_stars=1e5, random_state=11)
         csp = ssp + ssp_2
         self.assertEqual(200000, csp.num_stars)
@@ -75,13 +75,18 @@ class TestStars(TestCase):
     def test_add_extinction(self):
         """Test that extinction is applied to SSPs correctly."""
         ssp_no_ext = SSP(self.iso, num_stars=1e6, random_state=1)
+
         ssp_with_ext = SSP(self.iso, num_stars=1e6, random_state=1, a_lam=1.0)
+        self.assertDictEqual(ssp_with_ext.a_lam, {f'LSST_{f}': 1.0 for f in 'ugrizy'})
 
         m_no_ext = ssp_no_ext.total_mag('LSST_i')
         m_with_ext = ssp_with_ext.total_mag('LSST_i')
         self.assertAlmostEqual(1.0, m_with_ext - m_no_ext)
 
-        ssp_with_ext = SSP(self.iso, num_stars=1e6, random_state=1, a_lam=dict(LSST_i=2.0, LSST_g=1.0))
+        a_lam = dict(LSST_i=2.0, LSST_g=1.0)
+        ssp_with_ext = SSP(self.iso, num_stars=1e6, random_state=1, a_lam=a_lam.copy())
+        a_lam.update({f'LSST_{f}': 0.0 for f in 'urzy'})
+        self.assertDictEqual(ssp_with_ext.a_lam, a_lam)
 
         m_with_ext = ssp_with_ext.total_mag('LSST_i')
         self.assertAlmostEqual(2.0, m_with_ext - m_no_ext)


### PR DESCRIPTION
![giphy](https://user-images.githubusercontent.com/10998105/170163665-474089c5-e9be-4a7a-a638-8d135d96a406.gif)

## Overview

I realized today that my previous attempt at this (PR #9) had a bug – if you didn't give extinction for all filters (when using a dict), it would break when calculating the magnitudes for the missing filters, since it always tries to add extinction. 

This PR fixes this by creating a dictionary regardless of whether you give a single float or a dict for a subset of the filters.

## Example Behavior

For example, if you are using the LSST photometric system:

```python
# input at SSP instantiation -> saved a_lam attribute
a_lam = 5.0 -> a_lam = {'LSST_g': 5.0, 'LSST_r': 5.0, 'LSST_i': 5.0, 'LSST_z': 5.0, 'LSST_y': 5.0}


# input at SSP instantiation -> saved a_lam attribute
a_lam = {'LSST_i': 1.0}-> a_lam = {'LSST_g': 0.0, 'LSST_r': 0.0, 'LSST_i': 1.0, 'LSST_z': 0.0, 'LSST_y': 0.0}
```

## New Warnings

Given the way the code is currently written, the extinction bookkeeping gets messy if you want to add SSPs together to form a composite population object. Sorting that out is beyond the scope of this PR, so for now, a warning is given if the user tries to combine two SSPs with extinction. 

Finally, I noticed that we do not support smooth models when combining source objects into composite sources. Again, since this isn't a primary use case, I added a warning if the use tries to combine sources with smooth components.

