### PR TITLE
add astropy kernel calculation options to psf functions

### DIFF
--- a/src/artpop/image/imager.py
+++ b/src/artpop/image/imager.py
@@ -290,7 +290,7 @@ class ArtImager(Imager):
     Imager for making fully artificial images.
 
     .. note::
-        If you use a phot_system and its pre-calculated filter properties, the
+        If you use a `phot_system` and its pre-calculated filter properties, the
         conversion from magnitude to counts assumes AB magnitudes.
 
     Parameters

--- a/src/artpop/image/psf.py
+++ b/src/artpop/image/psf.py
@@ -19,7 +19,7 @@ def _check_shape(shape):
     return shape
 
 
-def gaussian_psf(fwhm, pixel_scale=0.2, shape=41):
+def gaussian_psf(fwhm, pixel_scale=0.2, shape=41, mode='center', factor=10):
     """
     Gaussian point-spread function.
 
@@ -36,6 +36,23 @@ def gaussian_psf(fwhm, pixel_scale=0.2, shape=41):
     shape : int or list-like, optional
         Shape of the psf image. Must be odd. If an int is given, the x and y 
         dimensions will be set to this value: (shape, shape).
+    mode : str, optional
+        One of the following discretization modes:
+            * 'center' (default)
+                Discretize model by taking the value
+                at the center of the bin.
+            * 'linear_interp'
+                Discretize model by linearly interpolating
+                between the values at the corners of the bin.
+            * 'oversample'
+                Discretize model by taking the average
+                on an oversampled grid.
+            * 'integrate'
+                Discretize model by integrating the
+                model over the bin. Very slow.
+    factor : number, optional
+        Factor of oversampling. Default factor = 10. If the factor
+        is too large, evaluation can be very slow.
 
     Returns
     -------
@@ -49,16 +66,21 @@ def gaussian_psf(fwhm, pixel_scale=0.2, shape=41):
 
     width = fwhm.to('pixel', u.pixel_scale(pixel_scale)).value
     width *= gaussian_fwhm_to_sigma
-    model = Gaussian2DKernel(x_stddev=width,
-                             y_stddev=width,
-                             x_size=x_size,
-                             y_size=y_size)
+    model = Gaussian2DKernel(
+        x_stddev=width,
+        y_stddev=width,
+        x_size=x_size,
+        y_size=y_size,
+        mode=mode,
+        factor=factor
+    )
     model.normalize()
     psf = model.array
     return psf
 
 
-def moffat_psf(fwhm, pixel_scale=0.2, shape=41, alpha=4.765):
+def moffat_psf(fwhm, pixel_scale=0.2, shape=41, alpha=4.765,
+               mode='center', factor=10):
     """
     Moffat point-spread function.
 
@@ -75,6 +97,23 @@ def moffat_psf(fwhm, pixel_scale=0.2, shape=41, alpha=4.765):
         dimensions will be set to this value: (shape, shape).
     alpha : float, optional
         Power index of the Moffat model.
+    mode : str, optional
+        One of the following discretization modes:
+            * 'center' (default)
+                Discretize model by taking the value
+                at the center of the bin.
+            * 'linear_interp'
+                Discretize model by linearly interpolating
+                between the values at the corners of the bin.
+            * 'oversample'
+                Discretize model by taking the average
+                on an oversampled grid.
+            * 'integrate'
+                Discretize model by integrating the
+                model over the bin. Very slow.
+    factor : number, optional
+        Factor of oversampling. Default factor = 10. If the factor
+        is too large, evaluation can be very slow.
 
     Returns
     -------
@@ -93,10 +132,14 @@ def moffat_psf(fwhm, pixel_scale=0.2, shape=41, alpha=4.765):
 
     width = fwhm.to('pixel', u.pixel_scale(pixel_scale)).value
     gamma = width / (2 * np.sqrt(2**(1 / alpha) - 1))
-    model = Moffat2DKernel(gamma=gamma,
-                           alpha=alpha,
-                           x_size=x_size,
-                           y_size=y_size)
+    model = Moffat2DKernel(
+        gamma=gamma,
+        alpha=alpha,
+        x_size=x_size,
+        y_size=y_size,
+        mode=mode,
+        factor=factor
+    )
     model.normalize()
     psf = model.array
     return psf

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -17,10 +17,10 @@ class TestImage(TestCase):
         self.psf = artpop.moffat_psf(0.6, pixel_scale=0.2)
         self.src = artpop.Source(
             xy=np.array([[109.5,  71.7],
-                         [ 36.6, 111.7],
-                         [ 40.3, 107.7],
+                         [36.6, 111.7],
+                         [40.3, 107.7],
                          [166.7, 199.4],
-                         [ 86.8, 160.9]]),
+                         [86.8, 160.9]]),
             mags=dict(LSST_i=np.array([10.1, 20.4, 30.2, 20.5, 8.2])),
             xy_dim=201,
             pixel_scale=0.2


### PR DESCRIPTION
This PR updates the PSF functions, `gaussian_psf` and `moffat_psf`, to give the user access to the `astropy` kernel calculations options: center, linear_interp, oversample, and integrate.
