### PR TITLE
Fix bugs in latest Python

### DIFF
--- a/src/artpop/stars/isochrones.py
+++ b/src/artpop/stars/isochrones.py
@@ -630,7 +630,7 @@ class MISTIsochrone(Isochrone):
             logger.debug('Using nearest log_age = {:.2f}'.format(self.log_age))
 
         # store phot_system as list to allow multiple photometric systems
-        if type(phot_system) == str:
+        if isinstance(phot_system, str):
             phot_system = [phot_system]
 
         # fetch first isochrone grid, interpolating on [Fe/H] if necessary

--- a/src/artpop/util.py
+++ b/src/artpop/util.py
@@ -51,7 +51,7 @@ def check_random_state(seed):
         return np.random.mtrand._rand
     if isinstance(seed, (numbers.Integral, np.integer)):
         return np.random.RandomState(seed)
-    if isinstance(seed, np.random.RandomState):
+    if isinstance(seed, np.random.RandomState) or isinstance(np.random.Generator):
         return seed
     if type(seed)==list:
         if type(seed[0])==int:


### PR DESCRIPTION
This fixes a couple of bugs I have ran into:

1. Using `type(phot_system) == str` => `isinstance(phot_system, str)`. For me it was for some reason the current check didn't work, and `"HSC"` was not detected as a string, and ending up passing `"H"` to the isochrone grid (i.e., the first element of that list).
2. The default numpy generator is subclassed to `np.random.Generator` so the current detector doesn't work. This adds another check for that.
