### PR TITLE
fix missing argument to isinstance

### DIFF
--- a/src/artpop/util.py
+++ b/src/artpop/util.py
@@ -51,7 +51,7 @@ def check_random_state(seed):
         return np.random.mtrand._rand
     if isinstance(seed, (numbers.Integral, np.integer)):
         return np.random.RandomState(seed)
-    if isinstance(seed, np.random.RandomState) or isinstance(np.random.Generator):
+    if isinstance(seed, np.random.RandomState) or isinstance(seed, np.random.Generator):
         return seed
     if type(seed)==list:
         if type(seed[0])==int:


### PR DESCRIPTION
Looks like there's a typo here that only gets triggered when someone passes in a non-`RandomState`.  This should fix it!